### PR TITLE
hotfix(InputWidgets): changes QTextEdit from FileDialog and DirectoryDialog to QTextBrowser, minor changes

### DIFF
--- a/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.cpp
+++ b/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.cpp
@@ -71,7 +71,7 @@ InputWidgets::FileDialog::FileDialog(const QJsonObject& json, QWidget* parent) :
                    &InputWidgets::FileDialog::receiveOnValueChanged);
 
   parameterLayout.addWidget(&textBrowser);
-  pushButton.setText("📁");
+  pushButton.setText("📄");
   parameterLayout.addWidget(&pushButton);
   inputMethodLayout.addLayout(&parameterLayout);
 
@@ -120,7 +120,7 @@ InputWidgets::DirectoryDialog::DirectoryDialog(const QJsonObject& json, QWidget*
                    &InputWidgets::DirectoryDialog::receiveOnValueChanged);
 
   parameterLayout.addWidget(&textBrowser);
-  pushButton.setText("📁");
+  pushButton.setText("📂");
   parameterLayout.addWidget(&pushButton);
   inputMethodLayout.addLayout(&parameterLayout);
 

--- a/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.h
+++ b/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.h
@@ -48,7 +48,7 @@ namespace InputWidgets {
     QString defaultDirectory;
     QString backup;
 
-    QTextEdit textBrowser;
+    QTextBrowser textBrowser;
     QPushButton pushButton;
 
     QHBoxLayout parameterLayout;
@@ -68,7 +68,7 @@ namespace InputWidgets {
     QString defaultDirectory;
     QString backup;
 
-    QTextEdit textBrowser;
+    QTextBrowser textBrowser;
     QPushButton pushButton;
 
     QHBoxLayout parameterLayout;

--- a/include/soccer-common/Parameters/ParameterType/ParameterType.h
+++ b/include/soccer-common/Parameters/ParameterType/ParameterType.h
@@ -248,7 +248,9 @@ namespace Parameters {
         filter(std::move(t_filter)),
         defaultDirectory(std::move(t_defaultDirectory)) {
       if (!Utils::removeQuotes(static_cast<QString>(value())).isEmpty()) {
-        throw std::runtime_error("t_ref must be empty.");
+        if (!QFile::exists(Utils::removeQuotes(static_cast<QString>(value())))) {
+          throw std::runtime_error("t_ref must be empty or a valid file.");
+        }
       }
     }
 
@@ -297,7 +299,9 @@ namespace Parameters {
         options(MagicEnum::name(t_options)),
         defaultDirectory(std::move(t_defaultDirectory)) {
       if (!Utils::removeQuotes(static_cast<QString>(value())).isEmpty()) {
-        throw std::runtime_error("t_ref must be empty.");
+        if (!QDir(Utils::removeQuotes(static_cast<QString>(value()))).exists()) {
+          throw std::runtime_error("t_ref must be empty or a valid directory.");
+        }
       }
     }
 
@@ -390,11 +394,12 @@ namespace Parameters {
 
     static_assert(std::is_floating_point_v<T>, "unsupported type.");
 
-    value_type minValue;
-    value_type maxValue;
-    int precision;
+    value_type minValue{};
+    value_type maxValue{};
+    int precision{};
 
-    DoubleSpinBox(Arg<T>& t_ref, const QString& t_about = "") : ParameterType<T>(t_ref, t_about) {
+    explicit DoubleSpinBox(Arg<T>& t_ref, const QString& t_about = "") :
+        ParameterType<T>(t_ref, t_about) {
     }
 
    public:


### PR DESCRIPTION
- Nos parâmetros como File e Directory, valores default podem ser arquivos e pastas existentes;
- Ajuste nos emojis dos botões de File e Directory;
- Altera de QTextEdit para QTextBrowser (não editável);