### PR TITLE
hotfix(InputWidgets): changes QTextEdit from FileDialog and DirectoryDialog to QTextBrowser, minor changes

### DIFF
--- a/include/soccer-common/Field/Field.h
+++ b/include/soccer-common/Field/Field.h
@@ -59,7 +59,7 @@ namespace Common {
       return m_penaltyAreaWidth;
     }
 
-    // size is equals to the field size + goal sizes.
+    // size is equals to the field size + goals depth.
     constexpr PT size() const {
       return PT(length() + 2 * goalDepth(), width());
     }

--- a/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.cpp
+++ b/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.cpp
@@ -71,7 +71,7 @@ InputWidgets::FileDialog::FileDialog(const QJsonObject& json, QWidget* parent) :
                    &InputWidgets::FileDialog::receiveOnValueChanged);
 
   parameterLayout.addWidget(&textBrowser);
-  pushButton.setText("📁");
+  pushButton.setText("📄");
   parameterLayout.addWidget(&pushButton);
   inputMethodLayout.addLayout(&parameterLayout);
 
@@ -120,7 +120,7 @@ InputWidgets::DirectoryDialog::DirectoryDialog(const QJsonObject& json, QWidget*
                    &InputWidgets::DirectoryDialog::receiveOnValueChanged);
 
   parameterLayout.addWidget(&textBrowser);
-  pushButton.setText("📁");
+  pushButton.setText("📂");
   parameterLayout.addWidget(&pushButton);
   inputMethodLayout.addLayout(&parameterLayout);
 

--- a/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.h
+++ b/include/soccer-common/Gui/Widgets/InputWidgets/InputWidgets.h
@@ -48,7 +48,7 @@ namespace InputWidgets {
     QString defaultDirectory;
     QString backup;
 
-    QTextEdit textBrowser;
+    QTextBrowser textBrowser;
     QPushButton pushButton;
 
     QHBoxLayout parameterLayout;
@@ -68,7 +68,7 @@ namespace InputWidgets {
     QString defaultDirectory;
     QString backup;
 
-    QTextEdit textBrowser;
+    QTextBrowser textBrowser;
     QPushButton pushButton;
 
     QHBoxLayout parameterLayout;

--- a/include/soccer-common/Parameters/ParameterType/ParameterType.h
+++ b/include/soccer-common/Parameters/ParameterType/ParameterType.h
@@ -248,7 +248,9 @@ namespace Parameters {
         filter(std::move(t_filter)),
         defaultDirectory(std::move(t_defaultDirectory)) {
       if (!Utils::removeQuotes(static_cast<QString>(value())).isEmpty()) {
-        throw std::runtime_error("t_ref must be empty.");
+        if (!QFile::exists(Utils::removeQuotes(static_cast<QString>(value())))) {
+          throw std::runtime_error("t_ref must be empty or a valid file.");
+        }
       }
     }
 
@@ -297,7 +299,9 @@ namespace Parameters {
         options(MagicEnum::name(t_options)),
         defaultDirectory(std::move(t_defaultDirectory)) {
       if (!Utils::removeQuotes(static_cast<QString>(value())).isEmpty()) {
-        throw std::runtime_error("t_ref must be empty.");
+        if (!QDir(Utils::removeQuotes(static_cast<QString>(value()))).exists()) {
+          throw std::runtime_error("t_ref must be empty or a valid directory.");
+        }
       }
     }
 
@@ -390,11 +394,12 @@ namespace Parameters {
 
     static_assert(std::is_floating_point_v<T>, "unsupported type.");
 
-    value_type minValue;
-    value_type maxValue;
-    int precision;
+    value_type minValue{};
+    value_type maxValue{};
+    int precision{};
 
-    DoubleSpinBox(Arg<T>& t_ref, const QString& t_about = "") : ParameterType<T>(t_ref, t_about) {
+    explicit DoubleSpinBox(Arg<T>& t_ref, const QString& t_about = "") :
+        ParameterType<T>(t_ref, t_about) {
     }
 
    public:

--- a/include/soccer-common/Parameters/ParameterType/ParameterType.h
+++ b/include/soccer-common/Parameters/ParameterType/ParameterType.h
@@ -269,8 +269,10 @@ namespace Parameters {
 
     bool update(const QString& str) override final {
       if (auto op = eval(str)) {
-        setValue(*op);
-        return true;
+        if (op.value().isEmpty() || QFile::exists(op.value())) {
+          setValue(*op);
+          return true;
+        }
       }
       return false;
     }
@@ -320,8 +322,10 @@ namespace Parameters {
 
     bool update(const QString& str) override final {
       if (auto op = eval(str)) {
-        setValue(*op);
-        return true;
+        if (op.value().isEmpty() || QDir(op.value()).exists()) {
+          setValue(*op);
+          return true;
+        }
       }
       return false;
     }

--- a/include/soccer-common/Utils/SharedOptional/SharedOptional.h
+++ b/include/soccer-common/Utils/SharedOptional/SharedOptional.h
@@ -34,6 +34,12 @@ class SharedOptional : public std::optional<T> {
     return ret;
   }
 
+  std::optional<T> getOptionalAndReset() {
+    std::optional<T> ret(std::move(static_cast<std::optional<T>&>(*this)));
+    std::optional<T>::reset();
+    return ret;
+  }
+
   template <class U>
   bool extract_to(U& other) {
     if (has_value()) {

--- a/include/soccer-common/Utils/SharedOptional/SharedOptional.h
+++ b/include/soccer-common/Utils/SharedOptional/SharedOptional.h
@@ -34,10 +34,18 @@ class SharedOptional : public std::optional<T> {
     return ret;
   }
 
+  T get_and_reset() {
+    return getAndReset();
+  }
+
   std::optional<T> getOptionalAndReset() {
     std::optional<T> ret(std::move(static_cast<std::optional<T>&>(*this)));
     std::optional<T>::reset();
     return ret;
+  }
+
+  std::optional<T> get_optional_and_reset() {
+    return getOptionalAndReset();
   }
 
   template <class U>


### PR DESCRIPTION
- Nos parâmetros como File e Directory, valores default podem ser arquivos e pastas existentes;
- Ajuste nos emojis dos botões de File e Directory;
- Altera de QTextEdit para QTextBrowser (não editável);