### PR TITLE
feat(ParametersWindow): Add ToolBox and TabWidgets

### DIFF
--- a/include/soccer-common/Gui/Widgets/ParametersWindow/ParametersWindow.h
+++ b/include/soccer-common/Gui/Widgets/ParametersWindow/ParametersWindow.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 #include <QJsonObject>
 
+class QTabWidget;
 class ParameterWidget;
 
 namespace Ui {
@@ -44,6 +45,10 @@ class ParametersWindow : public QWidget {
                            QStringList& currentPath,
                            const QString& name,
                            const QJsonObject& json);
+  void addParametersTab(QMap<QStringList, ParameterWidget*>& widgets,
+                        QStringList& currentPath,
+                        const QString& name,
+                        const QJsonObject& json);
 };
 
 #endif // SOCCER_COMMON_PARAMETERSWINDOW_H

--- a/include/soccer-common/Gui/Widgets/ParametersWindow/ParametersWindow.h
+++ b/include/soccer-common/Gui/Widgets/ParametersWindow/ParametersWindow.h
@@ -45,6 +45,10 @@ class ParametersWindow : public QWidget {
                            QStringList& currentPath,
                            const QString& name,
                            const QJsonObject& json);
+  void addParametersTool(QMap<QStringList, ParameterWidget*>& widgets,
+                         QStringList& currentPath,
+                         const QString& name,
+                         const QJsonObject& json);
   void addParametersTab(QMap<QStringList, ParameterWidget*>& widgets,
                         QStringList& currentPath,
                         const QString& name,

--- a/include/soccer-common/Parameters/ParameterType/ParameterType.h
+++ b/include/soccer-common/Parameters/ParameterType/ParameterType.h
@@ -41,6 +41,7 @@ namespace Parameters {
     static constexpr const char* Filter = "Filter";
     static constexpr const char* DefaultDirectory = "DefaultDirectory";
     static constexpr const char* Tab = "Tab";
+    static constexpr const char* Tool = "Tool";
   } // namespace Detail
 
   struct ParameterBase {

--- a/include/soccer-common/Parameters/ParameterType/ParameterType.h
+++ b/include/soccer-common/Parameters/ParameterType/ParameterType.h
@@ -40,6 +40,7 @@ namespace Parameters {
     static constexpr const char* Parent = "Parent";
     static constexpr const char* Filter = "Filter";
     static constexpr const char* DefaultDirectory = "DefaultDirectory";
+    static constexpr const char* Tab = "Tab";
   } // namespace Detail
 
   struct ParameterBase {

--- a/include/soccer-common/Utils/StateMachine/StateMachine.h
+++ b/include/soccer-common/Utils/StateMachine/StateMachine.h
@@ -30,8 +30,8 @@ class StateMachine {
       std::invoke_result_t<decltype(PointerToMatchingFunctorDeclval<T, Fs...>)>>;
 
  public:
-  using return_type = decltype(
-      std::visit(std::declval<overloaded_visitor_t<Functors...>>(), std::declval<State>()));
+  using return_type = decltype(std::visit(std::declval<overloaded_visitor_t<Functors...>>(),
+                                          std::declval<State>()));
 
   StateMachine() requires(std::default_initializable<State>) = default;
 

--- a/include/soccer-common/Utils/meta/static_block/static_block.h
+++ b/include/soccer-common/Utils/meta/static_block/static_block.h
@@ -6,7 +6,7 @@
 namespace __rc_meta { // NOLINT(bugprone-reserved-identifier)
   struct [[maybe_unused]] static_block_tag {
     template <class Functor>
-    inline explicit static_block_tag(Functor && f) {
+    inline explicit static_block_tag(Functor&& f) {
       std::forward<Functor>(f)();
     }
     ~static_block_tag() = default;
@@ -16,7 +16,7 @@ namespace __rc_meta { // NOLINT(bugprone-reserved-identifier)
     static_block_tag& operator=(const static_block_tag&) = delete;
 
     // disable_move:
-    static_block_tag(static_block_tag &&) = delete;
+    static_block_tag(static_block_tag&&) = delete;
     static_block_tag& operator=(static_block_tag&&) = delete;
   };
 } // namespace __rc_meta


### PR DESCRIPTION
This PR adds the possibility of organizing parameters into Tabs or Items, reducing the current visual load:

* [ToolBox](https://doc.qt.io/qt-6/qtoolbox.html);
* [TabWidget](https://doc.qt.io/qt-6/qtabwidget.html);

To do this, during the construction of the parameters, it is necessary to add a subgroup as:

```cpp
parameters["Tab"]["A"] = ...;
parameters["Tab"]["B"] = ...;
parameters["Tab"]["C"] = ...;
parameters["Tab"]["D"] = ...;

// or

parameters["Tool"]["A"] = ...;
parameters["Tool"]["B"] = ...;
parameters["Tool"]["C"] = ...;
parameters["Tool"]["D"] = ...;
```

> Backwards compatibility is maintained even with this change.